### PR TITLE
Fix global_packages enumeration

### DIFF
--- a/lib/pub_cache.dart
+++ b/lib/pub_cache.dart
@@ -96,8 +96,11 @@ class PubCache {
 
     Directory globalPackagesDir = _getSubDir(location, 'global_packages');
     if (globalPackagesDir.existsSync()) {
-      _applications = globalPackagesDir.listSync().map(
-          (dir) => new Application._(this, dir)).toList();
+      _applications = globalPackagesDir
+          .listSync()
+          .where((item) => item is Directory)
+          .map((dir) => new Application._(this, dir))
+          .toList();
     }
 
     // Scan hosted packages - just pub.dartlang.org for now.

--- a/test/pub_cache_test.dart
+++ b/test/pub_cache_test.dart
@@ -16,10 +16,37 @@ void defineTests() {
   final String cacheDirName = Platform.isWindows ? 'Cache' : 'pub-cache';
 
   group('PubCache', () {
+    tearDown(() {
+      Directory cacheDir = PubCache.getSystemCacheLocation();
+      var globalDir = new Directory(path.join(cacheDir.path, "global_packages"));
+      var file = new File(path.join(globalDir.path, "nonsense"));
+      if (file.existsSync()) {
+        file.deleteSync();
+      }
+    });
+
     test('getSystemCacheLocation', () {
       Directory cacheDir = PubCache.getSystemCacheLocation();
       expect(cacheDir, isNotNull);
       expect(path.basename(cacheDir.path), contains(cacheDirName));
+    });
+
+    test('Create PubCache when non-directories are in global_packages', () {
+      // Get cache in its current state
+      var cache = new PubCache();
+      var currentGlobalApps = cache.getGlobalApplications();
+
+      // Put a file in global_packages
+      Directory cacheDir = PubCache.getSystemCacheLocation();
+      var globalDir = new Directory(path.join(cacheDir.path, "global_packages"));
+      var file = new File(path.join(globalDir.path, "nonsense"));
+      file.writeAsStringSync("pub_cache test suite");
+
+      // Ensure that this file is not reflected in cache
+      cache = new PubCache();
+      var newGlobalApps = cache.getGlobalApplications();
+
+      expect(currentGlobalApps.length, newGlobalApps.length);
     });
 
     test('PubCache', () {


### PR DESCRIPTION
On macOS if you opened global_packages directory in Finder, it creates a .DS_Store entry. PubCache assumes all items in global_packages are Directories. This would cause an exception to be thrown when instantiating PubCache.